### PR TITLE
iframe no longer focusable with keyboard while hidden

### DIFF
--- a/packages/crate/src/app/Embed/index.tsx
+++ b/packages/crate/src/app/Embed/index.tsx
@@ -12,6 +12,7 @@ interface StateProps {
     shard: string
   }
   interactive: boolean
+  open: boolean
 }
 
 class Embed extends React.PureComponent<StateProps> {
@@ -37,7 +38,7 @@ class Embed extends React.PureComponent<StateProps> {
   }
 
   render() {
-    const { options } = this.props
+    const { options, open } = this.props
     const { deferred } = this.state
 
     return (
@@ -52,6 +53,7 @@ class Embed extends React.PureComponent<StateProps> {
               defer={deferred}
               onAPI={onAPI}
               className="react-embed"
+              focusable={open}
             />
           )}
         </APIContext.Consumer>
@@ -61,12 +63,13 @@ class Embed extends React.PureComponent<StateProps> {
 }
 
 export default connect<StateProps, {}, {}, State>(
-  ({ interactive, options }) => ({
+  ({ interactive, options, open }) => ({
     options: {
       server: options.server,
       channel: options.channel,
       shard: options.shard
     },
-    interactive
+    interactive,
+    open
   })
 )(Embed)

--- a/packages/react-embed/src/index.tsx
+++ b/packages/react-embed/src/index.tsx
@@ -17,6 +17,7 @@ export interface IProps {
   style?: React.CSSProperties
   height?: number
   width?: number
+  focusable?: boolean
 
   options?: { [key: string]: string }
 }
@@ -26,7 +27,8 @@ class WidgetBot extends React.PureComponent<IProps> {
     server: '299881420891881473',
     shard: 'https://widgetbot.io',
     options: {},
-    defer: false
+    defer: false,
+    focusable: true
   }
 
   state = {
@@ -57,7 +59,7 @@ class WidgetBot extends React.PureComponent<IProps> {
   }
 
   render() {
-    const { defer, className, style, height, width } = this.props
+    const { defer, className, style, height, width, focusable } = this.props
 
     return (
       <div
@@ -68,6 +70,7 @@ class WidgetBot extends React.PureComponent<IProps> {
           src={defer ? '' : this.state.url}
           ref={ref => (this.api.iframe = ref)}
           style={Embed}
+          tabIndex={focusable ? null : -1}
         />
       </div>
     )


### PR DESCRIPTION
Even though the *crate* was closed it was still possible to navigate into the hidden *embed* `iframe` using the `tab` key which also messed up tab-based navigation.

This fix adds `tabindex="-1"` on the `iframe` while the `crate` is closed to prevent it from being focused.