### PR TITLE
Fixed some broken compile settings

### DIFF
--- a/packages/react-embed/tsconfig.json
+++ b/packages/react-embed/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
     "allowJs": false,

--- a/packages/scripts/nwb.config.js
+++ b/packages/scripts/nwb.config.js
@@ -1,3 +1,6 @@
+const fs = require('fs')
+const path = require('path')
+
 module.exports = () => ({
   type: 'react-component',
   npm: {
@@ -15,7 +18,15 @@ module.exports = () => ({
     config(config) {
       config.module.rules.push({
         test: /\.tsx?$/,
-        use: ['babel-loader', 'ts-loader']
+        use: [
+          {
+            loader: 'babel-loader',
+            options: JSON.parse(
+              fs.readFileSync(path.join(__dirname, '.babelrc'), 'utf8')
+            )
+          },
+          'ts-loader'
+        ]
       })
 
       config.entry = config.entry.map(


### PR DESCRIPTION
Trying to build the *crate* failed with the following error:

```
$ yarn workspace @widgetbot/crate build

Module build failed (from …/widgetbot/node_modules/babel-loader/lib/index.js):
SyntaxError: Unexpected token (16:20)

  14 | const render = (_a) => {
  15 |     var { node, store } = _a, props = __rest(_a, ["node", "store"]);
> 16 |     ReactDOM.render(<Provider store={store}>
     |                     ^
  17 |       <App {...props}/>
  18 |     </Provider>, node);
  19 |     return node;

 @ ./src/api/index.ts 21:0-32 63:8-14
 @ ./src/umd.ts
 @ multi ./src/umd.ts
```

The root cause was that in `packages/scripts/nwb.config.js` a `babel-loader` for `.tsx` files has been added without providing a babel configuration. This change will use `.babelrc` from the same folder for that.

Additionally *crate's* dependency *react-embed* could not be built because its parent TypeScript configuration `../../tsconfig.json` was no found. I've corrected the path to `../script/tsconfig.json` - the same as the other packages are using.