### PR TITLE
Update base.js - Self hosting

### DIFF
--- a/packages/server/scripts/webpack/base.js
+++ b/packages/server/scripts/webpack/base.js
@@ -59,6 +59,6 @@ module.exports = (overrides = {}) => ({
   },
   resolve: {
     plugins: [new TsConfigPathsPlugin()],
-    extensions: ['.ts', '.js']
+    extensions: ['.mjs','.ts', '.js']
   }
 })


### PR DESCRIPTION
Resolve graphql error describe in : https://github.com/widgetbot-io/widgetbot/issues/66
7 error remind for me after this fix :
```
ERROR in [at-loader] ./node_modules/@types/node/index.d.ts:74:15
    TS2300: Duplicate identifier 'SharedArrayBuffer'.

ERROR in [at-loader] ./node_modules/@types/react/index.d.ts:2746:14
    TS2300: Duplicate identifier 'LibraryManagedAttributes'.

ERROR in [at-loader] ./src/engine/util/fetchChannel.ts:39:49
    TS2345: Argument of type 'PermissionResolvable[]' is not assignable to parameter of type 'PermissionResolvable'.
  Type 'PermissionResolvable[]' is not assignable to type '(number | Permissions | "ADMINISTRATOR" | "CREATE_INSTANT_INVITE" | "KICK_MEMBERS" | "BAN_MEMBERS...'.
    Type 'PermissionResolvable' is not assignable to type 'number | Permissions | "ADMINISTRATOR" | "CREATE_INSTANT_INVITE" | "KICK_MEMBERS" | "BAN_MEMBERS"...'.
      Type '(number | Permissions | "ADMINISTRATOR" | "CREATE_INSTANT_INVITE" | "KICK_MEMBERS" | "BAN_MEMBERS...' is not assignable to type 'number | Permissions | "ADMINISTRATOR" | "CREATE_INSTANT_INVITE" | "KICK_MEMBERS" | "BAN_MEMBERS"...'.
        Type '(number | Permissions | "ADMINISTRATOR" | "CREATE_INSTANT_INVITE" | "KICK_MEMBERS" | "BAN_MEMBERS...' is not assignable to type '"MANAGE_EMOJIS"'.

ERROR in [at-loader] ..\..\node_modules\@types\react-redux\index.d.ts:118:29
    TS2370: A rest parameter must be of an array type.

ERROR in [at-loader] ..\..\node_modules\@types\react-redux\index.d.ts:119:12
    TS2370: A rest parameter must be of an array type.

ERROR in [at-loader] ..\..\node_modules\@types\react-virtualized\dist\es\WindowScroller.d.ts:33:28
    TS2304: Cannot find name 'window'.

ERROR in [at-loader] ..\..\node_modules\@types\react-virtualized\dist\es\WindowScroller.d.ts:70:24
    TS2304: Cannot find name 'Window'.
```